### PR TITLE
fix: remove duplicate allowlist initialization in shell exec tool

### DIFF
--- a/pkg/tools/shell.go
+++ b/pkg/tools/shell.go
@@ -39,11 +39,6 @@ func NewExecTool(cfg config.ShellConfig, workspace string) *ExecTool {
 		allowPatterns = append(allowPatterns, regexp.MustCompile(`(?i)\b`+regexp.QuoteMeta(p)+`\b`))
 	}
 
-	allowPatterns := make([]*regexp.Regexp, 0, len(cfg.AllowedCmds))
-	for _, p := range cfg.AllowedCmds {
-		allowPatterns = append(allowPatterns, regexp.MustCompile(`\b`+regexp.QuoteMeta(p)+`\b`))
-	}
-
 	return &ExecTool{
 		workingDir:          workspace,
 		timeout:             cfg.Timeout,


### PR DESCRIPTION
### Motivation
- Remove a duplicated `allowPatterns` initialization in `NewExecTool` that caused a compile-time error (`no new variables on left side of :=`) and blocked running `go test ./...`.

### Description
- Deleted the redundant `allowPatterns` declaration and preserved the intended case-insensitive allowlist regex construction in `pkg/tools/shell.go`.

### Testing
- Ran `go test ./...` and `go vet ./...`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69900fedacb4832c9480118291bc4b5f)