### PR TITLE
fix: improve cron runtime observability and deterministic sleep calculation

### DIFF
--- a/pkg/cron/service_test.go
+++ b/pkg/cron/service_test.go
@@ -72,6 +72,31 @@ func TestNextSleepDuration(t *testing.T) {
 	}
 }
 
+func TestNextSleepDuration_UsesProvidedNow(t *testing.T) {
+	cs := &CronService{
+		opts: RuntimeOptions{
+			RunLoopMinSleep: 1 * time.Second,
+			RunLoopMaxSleep: 30 * time.Second,
+		},
+		running: map[string]struct{}{},
+		store:   &CronStore{Jobs: []CronJob{}},
+	}
+
+	now := time.UnixMilli(10_000)
+	next := int64(15_000)
+	cs.store.Jobs = []CronJob{{
+		ID:      "1",
+		Enabled: true,
+		State: CronJobState{
+			NextRunAtMS: &next,
+		},
+	}}
+
+	if got := cs.nextSleepDuration(now); got != 5*time.Second {
+		t.Fatalf("expected 5s sleep from provided now, got %s", got)
+	}
+}
+
 func TestCheckJobs_NoConcurrentRunForSameJob(t *testing.T) {
 	var running int32
 	var maxRunning int32


### PR DESCRIPTION
### Motivation
- Surface and preserve store persistence failures instead of discarding them so runtime operators can detect and react to `saveStore` errors. 
- Make `nextSleepDuration(now time.Time)` deterministic by respecting the provided `now` argument, which fixes a semantics mismatch and improves testability. 
- Add a regression test to lock in the deterministic sleep behavior. 
- No skills were used for this change because it is a focused code repair to the cron runtime.

### Description
- Add `lastSaveError string` to `CronService` to hold the most recent `saveStore` error. 
- Update mutation paths that previously ignored `saveStore` errors (`checkJobs`, `removeJobUnsafe`, `EnableJob`) to set or clear `lastSaveError` based on the result of `saveStore`. 
- Expose `lastSaveError` in `CronService.Status()` to make persistence failures observable via the status API. 
- Change `nextSleepDuration(now time.Time)` to compute sleep using `time.UnixMilli(*nextWake).Sub(now)` and add `TestNextSleepDuration_UsesProvidedNow` to ensure the function uses the provided time argument.

### Testing
- Ran `gofmt -w pkg/cron/service.go pkg/cron/service_test.go` to normalize formatting and ensure no gofmt issues. (succeeded.)
- Ran `go test ./pkg/cron ./pkg/config` which passed for the cron package. (succeeded.)
- Ran `go test ./...` to validate the full test suite for packages in the repo, which completed successfully for the tested packages. (succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991bed2e340832c8da71c312d124b78)