### PR TITLE
fix(cron): preserve reminder delivery target from session context

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -387,9 +387,13 @@ func (al *AgentLoop) tryFallbackProviders(ctx context.Context, msg bus.InboundMe
 
 func (al *AgentLoop) setSessionProvider(sessionKey, provider string) {
 	key := strings.TrimSpace(sessionKey)
-	if key == "" { return }
+	if key == "" {
+		return
+	}
 	provider = strings.TrimSpace(provider)
-	if provider == "" { return }
+	if provider == "" {
+		return
+	}
 	al.providerMu.Lock()
 	al.sessionProvider[key] = provider
 	al.providerMu.Unlock()
@@ -397,7 +401,9 @@ func (al *AgentLoop) setSessionProvider(sessionKey, provider string) {
 
 func (al *AgentLoop) getSessionProvider(sessionKey string) string {
 	key := strings.TrimSpace(sessionKey)
-	if key == "" { return "" }
+	if key == "" {
+		return ""
+	}
 	al.providerMu.RLock()
 	v := al.sessionProvider[key]
 	al.providerMu.RUnlock()
@@ -701,6 +707,11 @@ func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage)
 	if tool, ok := al.tools.Get("spawn"); ok {
 		if st, ok := tool.(*tools.SpawnTool); ok {
 			st.SetContext(msg.Channel, msg.ChatID)
+		}
+	}
+	if tool, ok := al.tools.Get("remind"); ok {
+		if rt, ok := tool.(*tools.RemindTool); ok {
+			rt.SetContext(msg.Channel, msg.ChatID)
 		}
 	}
 

--- a/pkg/tools/remind.go
+++ b/pkg/tools/remind.go
@@ -9,11 +9,18 @@ import (
 )
 
 type RemindTool struct {
-	cs *cron.CronService
+	cs             *cron.CronService
+	defaultChannel string
+	defaultChatID  string
 }
 
 func NewRemindTool(cs *cron.CronService) *RemindTool {
 	return &RemindTool{cs: cs}
+}
+
+func (t *RemindTool) SetContext(channel, chatID string) {
+	t.defaultChannel = channel
+	t.defaultChatID = chatID
 }
 
 func (t *RemindTool) Name() string {
@@ -63,7 +70,7 @@ func (t *RemindTool) Execute(ctx context.Context, args map[string]interface{}) (
 			Kind: "at",
 			AtMS: &at,
 		}
-		job, err := t.cs.AddJob("Reminder", schedule, message, true, "", "") // deliver=true, channel="" means default
+		job, err := t.cs.AddJob("Reminder", schedule, message, true, t.defaultChannel, t.defaultChatID)
 		if err != nil {
 			return "", fmt.Errorf("failed to schedule reminder: %w", err)
 		}
@@ -113,7 +120,7 @@ func (t *RemindTool) Execute(ctx context.Context, args map[string]interface{}) (
 		AtMS: &at,
 	}
 
-	job, err := t.cs.AddJob("Reminder", schedule, message, true, "", "")
+	job, err := t.cs.AddJob("Reminder", schedule, message, true, t.defaultChannel, t.defaultChatID)
 	if err != nil {
 		return "", fmt.Errorf("failed to schedule reminder: %w", err)
 	}

--- a/pkg/tools/remind_test.go
+++ b/pkg/tools/remind_test.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"clawgo/pkg/cron"
+)
+
+func TestRemindTool_UsesToolContextForDeliveryTarget(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "jobs.json")
+	cs := cron.NewCronService(storePath, nil)
+	tool := NewRemindTool(cs)
+	tool.SetContext("telegram", "chat-123")
+
+	_, err := tool.Execute(context.Background(), map[string]interface{}{
+		"message":   "喝水",
+		"time_expr": "10m",
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	jobs := cs.ListJobs(true)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+
+	if !jobs[0].Payload.Deliver {
+		t.Fatalf("expected deliver=true")
+	}
+	if jobs[0].Payload.Channel != "telegram" {
+		t.Fatalf("expected channel telegram, got %q", jobs[0].Payload.Channel)
+	}
+	if jobs[0].Payload.To != "chat-123" {
+		t.Fatalf("expected to chat-123, got %q", jobs[0].Payload.To)
+	}
+}


### PR DESCRIPTION
### Motivation

-  修复 `remind` 工具创建定时任务时未携带会话目标（channel/chatID）的问题，导致 `deliver=true` 的任务触发时无法走外发投递链路。 

### Description

- 在 `RemindTool` 中新增 `defaultChannel` 和 `defaultChatID` 字段并实现 `SetContext(channel, chatID)` 来保存当前会话上下文。 
- 在 `RemindTool.Execute` 中将 `AddJob` 的 `channel`/`to` 参数由空值替换为 `t.defaultChannel` / `t.defaultChatID`，确保持久化的任务包含投递目标。 
- 在 `AgentLoop` 的工具上下文更新位置注册 `remind` 工具的 `SetContext` 调用，保证每条消息处理时刷新提醒工具的会话上下文。 
- 新增回归测试 `pkg/tools/remind_test.go` 校验在设置上下文后创建的提醒任务其 `Payload.Deliver`、`Payload.Channel` 与 `Payload.To` 被正确持久化。 

### Testing

- 已运行格式化命令 `gofmt -w pkg/tools/remind.go pkg/tools/remind_test.go pkg/agent/loop.go`，格式化成功。 
- 运行单元测试 `go test ./pkg/tools ./pkg/agent ./pkg/cron -count=1`，`pkg/tools` 和 `pkg/agent` 测试通过，`pkg/cron` 无测试文件。 
- 新增回归测试 `pkg/tools/remind_test.go` 已执行并通过，验证提醒任务保存了正确的投递目标。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a59c310900832c913315f2917b581e)