### PR TITLE
Route system-channel outbound messages to origin channel and add test

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -616,12 +616,16 @@ func (al *AgentLoop) prepareOutbound(msg bus.InboundMessage, response string) (b
 	if al.shouldSuppressOutbound(msg, clean) {
 		return bus.OutboundMessage{}, false
 	}
-	return bus.OutboundMessage{
-		Channel:   msg.Channel,
-		ChatID:    msg.ChatID,
-		Content:   clean,
-		ReplyToID: strings.TrimSpace(replyToID),
-	}, true
+	outbound := bus.OutboundMessage{Channel: msg.Channel, ChatID: msg.ChatID, Content: clean, ReplyToID: strings.TrimSpace(replyToID)}
+	if msg.Channel == "system" {
+		if originChannel, originChatID, ok := strings.Cut(msg.ChatID, ":"); ok && strings.TrimSpace(originChannel) != "" {
+			outbound.Channel = originChannel
+			outbound.ChatID = originChatID
+		} else {
+			outbound.Channel = "cli"
+		}
+	}
+	return outbound, true
 }
 
 func (al *AgentLoop) ProcessDirect(ctx context.Context, content, sessionKey string) (string, error) {

--- a/pkg/agent/loop_session_regression_test.go
+++ b/pkg/agent/loop_session_regression_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"clawgo/pkg/bus"
 	"clawgo/pkg/config"
@@ -104,6 +105,27 @@ func TestProcessSystemMessage_UsesOriginSessionKey(t *testing.T) {
 	want := "[System: cron] " + rewriteSystemMessageContent("system task", loop.systemRewriteTemplate)
 	if !containsUserContent(second, want) {
 		t.Fatalf("expected system marker in follow-up history, want=%q got=%v", want, summarizeUsers(second))
+	}
+}
+
+func TestProcessInbound_SystemMessagePublishesToOriginChannel(t *testing.T) {
+	rp := &recordingProvider{}
+	loop := setupLoop(t, rp)
+
+	in := bus.InboundMessage{Channel: "system", SenderID: "cron", ChatID: "telegram:chat-1", Content: "system task"}
+	loop.processInbound(context.Background(), in)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	out, ok := loop.bus.SubscribeOutbound(ctx)
+	if !ok {
+		t.Fatalf("expected outbound message")
+	}
+	if out.Channel != "telegram" {
+		t.Fatalf("expected outbound channel telegram, got %q", out.Channel)
+	}
+	if out.ChatID != "chat-1" {
+		t.Fatalf("expected outbound chat_id chat-1, got %q", out.ChatID)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- System-originated inbound messages encoded an origin in `ChatID` but outbound messages continued to use the `system` channel, preventing replies from being delivered back to the originating channel.

### Description

- Update `prepareOutbound` to remap outbound `Channel` and `ChatID` when an inbound message has `Channel == "system"` by splitting `ChatID` on `":"` and falling back to `cli` when no origin is present.
- Construct an `outbound` variable to modify the message before returning, trimming `ReplyToID` and preserving original content and chat info.
- Add a new unit test `TestProcessInbound_SystemMessagePublishesToOriginChannel` in `loop_session_regression_test.go` and import `time` for test timeout handling.

### Testing

- Ran the package unit tests with `go test ./pkg/agent`, and the suite passed including the new `TestProcessInbound_SystemMessagePublishesToOriginChannel` test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5a11269c8832caff243b5a50e5783)