### PR TITLE
Fix WebUI installer to locate nested dist directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,8 +102,15 @@ if curl -fSL "$WEBUI_URL" -o "$WEBUI_OUT"; then
   mkdir -p "$WEBUI_TMP"
   tar -xzf "$WEBUI_OUT" -C "$WEBUI_TMP"
 
+  WEBUI_DIST_DIR=""
   if [[ -d "$WEBUI_TMP/dist" ]]; then
-    rsync -a --delete "$WEBUI_TMP/dist/" "$WEBUI_DIR/"
+    WEBUI_DIST_DIR="$WEBUI_TMP/dist"
+  else
+    WEBUI_DIST_DIR="$(find "$WEBUI_TMP" -mindepth 2 -maxdepth 4 -type d -name dist | head -n1)"
+  fi
+
+  if [[ -n "$WEBUI_DIST_DIR" && -d "$WEBUI_DIST_DIR" ]]; then
+    rsync -a --delete "$WEBUI_DIST_DIR/" "$WEBUI_DIR/"
   else
     rsync -a --delete "$WEBUI_TMP/" "$WEBUI_DIR/"
   fi


### PR DESCRIPTION
### Motivation

- Prevent the WebUI from being installed into a nested `dist` subdirectory under the target (`.../workspace/webui/dist`) when release archives wrap the `dist` folder inside another directory.

### Description

- Update `install.sh` WebUI extraction logic to search for a nested `dist` directory under the extracted archive and prefer syncing that directory into `WEBUI_DIR`.
- If a direct `webui_extract/dist` exists use it, otherwise use `find` to locate the first matching nested `dist` within a limited depth and sync that directory.
- Keep the existing fallback behavior of rsyncing the extraction root into `WEBUI_DIR` when no `dist` is found.
- Changes are contained in `install.sh` around the WebUI extraction section.

### Testing

- Ran a shell syntax check with `bash -n install.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5b946d544832c8ee0308528380f3e)